### PR TITLE
Fix 3DO Emulation (Metal only)

### DIFF
--- a/FreeDOGameCore.mm
+++ b/FreeDOGameCore.mm
@@ -495,8 +495,7 @@ static void writeSaveFile(const char* path)
 }
 
 - (GLenum)pixelType {
-    return GL_FLOAT_32_UNSIGNED_INT_24_8_REV;
-//    return GL_UNSIGNED_INT_8_8_8_8_REV;
+    return GL_UNSIGNED_BYTE;
 }
 
 - (const void *)videoBuffer {
@@ -541,6 +540,52 @@ static void writeSaveFile(const char* path)
 }
 
 #pragma mark - Input
+
+- (void)updateControllers
+{
+    if ([self.controller1 extendedGamepad])
+    {
+        GCExtendedGamepad *gamepad = [self.controller1 extendedGamepad];
+        GCControllerDirectionPad *dpad = [gamepad dpad];
+    
+        (dpad.up.isPressed || gamepad.leftThumbstick.up.isPressed) ? internal_input_state[0].buttons|=INPUTBUTTONUP : internal_input_state[0].buttons&=~INPUTBUTTONUP;
+        (dpad.down.isPressed || gamepad.leftThumbstick.down.isPressed) ? internal_input_state[0].buttons|=INPUTBUTTONDOWN : internal_input_state[0].buttons&=~INPUTBUTTONDOWN;
+        (dpad.left.isPressed || gamepad.leftThumbstick.left.isPressed) ? internal_input_state[0].buttons|=INPUTBUTTONLEFT : internal_input_state[0].buttons&=~INPUTBUTTONLEFT;
+        (dpad.right.isPressed || gamepad.leftThumbstick.right.isPressed) ? internal_input_state[0].buttons|=INPUTBUTTONRIGHT : internal_input_state[0].buttons&=~INPUTBUTTONRIGHT;
+
+        (gamepad.buttonA.isPressed) ? internal_input_state[0].buttons|=INPUTBUTTONA : internal_input_state[0].buttons&=~INPUTBUTTONA;
+        (gamepad.buttonB.isPressed) ? internal_input_state[0].buttons|=INPUTBUTTONB : internal_input_state[0].buttons&=~INPUTBUTTONB;
+        (gamepad.buttonY.isPressed) ? internal_input_state[0].buttons|=INPUTBUTTONC : internal_input_state[0].buttons&=~INPUTBUTTONC;
+
+        (gamepad.leftShoulder.isPressed) ? internal_input_state[0].buttons|=INPUTBUTTONL : internal_input_state[0].buttons&=~INPUTBUTTONL;
+        (gamepad.rightShoulder.isPressed) ? internal_input_state[0].buttons|=INPUTBUTTONR : internal_input_state[0].buttons&=~INPUTBUTTONR;
+        
+        (gamepad.leftTrigger.isPressed) ? internal_input_state[0].buttons|=INPUTBUTTONX : internal_input_state[0].buttons&=~INPUTBUTTONX;
+        (gamepad.rightTrigger.isPressed) ? internal_input_state[0].buttons|=INPUTBUTTONP : internal_input_state[0].buttons&=~INPUTBUTTONP;
+        
+    }
+    else if ([self.controller1 gamepad])
+    {
+        GCGamepad *gamepad = [self.controller1 gamepad];
+        GCControllerDirectionPad *dpad = [gamepad dpad];
+
+        (dpad.up.isPressed) ? internal_input_state[0].buttons|=INPUTBUTTONUP : internal_input_state[0].buttons&=~INPUTBUTTONP;
+        (dpad.down.isPressed) ? internal_input_state[0].buttons|=INPUTBUTTONDOWN : internal_input_state[0].buttons&=~INPUTBUTTONDOWN;
+        (dpad.left.isPressed) ? internal_input_state[0].buttons|=INPUTBUTTONLEFT : internal_input_state[0].buttons&=~INPUTBUTTONLEFT;
+        (dpad.right.isPressed) ? internal_input_state[0].buttons|=INPUTBUTTONRIGHT : internal_input_state[0].buttons&=~INPUTBUTTONRIGHT;
+
+        (gamepad.buttonA.isPressed) ? internal_input_state[0].buttons|=INPUTBUTTONA : internal_input_state[0].buttons&=~INPUTBUTTONA;
+        (gamepad.buttonB.isPressed) ? internal_input_state[0].buttons|=INPUTBUTTONB : internal_input_state[0].buttons&=~INPUTBUTTONB;
+        (gamepad.buttonY.isPressed) ? internal_input_state[0].buttons|=INPUTBUTTONC : internal_input_state[0].buttons&=~INPUTBUTTONC;
+
+        (gamepad.leftShoulder.isPressed) ? internal_input_state[0].buttons|=INPUTBUTTONL : internal_input_state[0].buttons&=~INPUTBUTTONL;
+        (gamepad.rightShoulder.isPressed) ? internal_input_state[0].buttons|=INPUTBUTTONR : internal_input_state[0].buttons&=~INPUTBUTTONR;
+        
+        (gamepad.buttonX.isPressed) ? internal_input_state[0].buttons|=INPUTBUTTONX : internal_input_state[0].buttons&=~INPUTBUTTONX;
+        //nothing to assign to P for legacy gamepad support
+//        (gamepad.buttonX.isPressed) ? internal_input_state[0].buttons|=INPUTBUTTONP : internal_input_state[0].buttons&=~INPUTBUTTONP;
+    }
+}
 - (void)didPush3DOButton:(PV3DOButton)button forPlayer:(NSInteger)player {
     player--;
     
@@ -717,6 +762,8 @@ char CalculateDeviceHighByte(int deviceNumber)
     assert(len==ROM1_SIZE);
     biosRom1Copy = (unsigned char *)malloc(len);
     memcpy(biosRom1Copy, [data bytes], len);
+    
+    //there's supposed to be a 3rd BIOS here, so add that later
     
     // "ROM 2 Japanese Character ROM" / Set it if we find it. It's not requiered for soem JAP games. We still have to init the memory tho
     NSString *rom2Path = [[self BIOSPath] stringByAppendingPathComponent:@"rom2.rom"];

--- a/libfreedo/arm.cpp
+++ b/libfreedo/arm.cpp
@@ -600,14 +600,37 @@ unsigned char * _arm_Init()
 
 void _arm_Destroy()
 {
-	io_interface(EXT_WRITE_NVRAM,pNVRam);//_3do_SaveNVRAM(pNVRam);
+    io_interface(EXT_WRITE_NVRAM,pNVRam);//_3do_SaveNVRAM(pNVRam);
 
+    if (profiling != NULL) {
         delete []profiling;
-		delete []profiling2;
-		delete []profiling3;
-	delete []pNVRam;
-	delete []pRom;
-	delete []pRam;
+        profiling = NULL;
+    }
+    
+    if (profiling2 != NULL) {
+        delete []profiling2;
+        profiling2 = NULL;
+    }
+    
+    if (profiling3 != NULL) {
+        delete []profiling3;
+        profiling3 = NULL;
+    }
+    
+    if (pNVRam != NULL) {
+        delete []pNVRam;
+        pNVRam = NULL;
+    }
+    
+    if (pRom != NULL) {
+        delete []pRom;
+        pRom = NULL;
+    }
+    
+    if (pRam != NULL) {
+        delete []pRam;
+        pRam = NULL;
+    }
 }
 
 void _arm_Reset()


### PR DESCRIPTION
### **User description**
This PR does 3 things:

1. Fixes rendering when using Metal rendering engine only.  OpenGL still renders a black screen (did before this PR too)
2. Adds support for game controller when emulating 3DO
3. Fixes a crash that occurred when quitting the game and trying to return to the game library screen.  

This PR does NOT:

1. fix 3DO emulation when rendering using OpenGL
2. add support for the 3rd BIOS type (added a comment in the code about that for later)
3. Add support for on-screen joypad (that needs to be done in the main library)

Testing

I tested using the following setup:

1. iPad Pro 11" 4th Gen (and a simulator running iOS 17.2)
2. PS5 Dual Sense Controller
4. Star Control 2 ROM

![Simulator Screenshot - iPad Pro 17 2 - 2024-08-13 at 20 54 45](https://github.com/user-attachments/assets/fabfb5b4-ac50-4963-91e4-f149f0af973c)
![Simulator Screenshot - iPad Pro 17 2 - 2024-08-13 at 20 55 54](https://github.com/user-attachments/assets/380b9d14-1920-4379-8753-a3b31d799470)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Improved memory management in `libfreedo/arm.cpp` by adding null checks before deleting pointers and setting them to NULL after deletion.
- Changed pixel type to `GL_UNSIGNED_BYTE` in `FreeDOGameCore.mm` to fix rendering issues when using Metal.
- Added support for game controllers, including extended gamepads, in `FreeDOGameCore.mm`.
- Added a placeholder comment for future support of a third BIOS in `FreeDOGameCore.mm`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>arm.cpp</strong><dd><code>Improve memory management and prevent crashes in `_arm_Destroy`</code></dd></summary>
<hr>

libfreedo/arm.cpp

<li>Added null checks before deleting pointers in <code>_arm_Destroy</code>.<br> <li> Ensured memory is properly freed and pointers are set to NULL.<br>


</details>


  </td>
  <td><a href="https://github.com/Provenance-Emu/4DO-Core/pull/1/files#diff-72449d0422fa0bc90a14645ca86e7deac2e1fd95c2f5d841959605387c856b75">+29/-6</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FreeDOGameCore.mm</strong><dd><code>Add game controller support and improve Metal rendering</code>&nbsp; &nbsp; </dd></summary>
<hr>

FreeDOGameCore.mm

<li>Changed pixel type to <code>GL_UNSIGNED_BYTE</code> for Metal rendering.<br> <li> Added support for game controllers, including extended gamepads.<br> <li> Added a placeholder comment for a third BIOS.<br>


</details>


  </td>
  <td><a href="https://github.com/Provenance-Emu/4DO-Core/pull/1/files#diff-526d3aa526b46f4c2a125dc3a87d455856771c5da6124d8e23f6e9748f0e90a5">+49/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

