### PR TITLE
fixes 3do crash on load due to duplicated instances in the Core init

### DIFF
--- a/Sources/PVFreeDOGameCore/FreeDOGameCore.swift
+++ b/Sources/PVFreeDOGameCore/FreeDOGameCore.swift
@@ -16,16 +16,12 @@ import PVFreeDOGameCoreOptions
 @objcMembers
 open class PVFreeDOGameCore : PVEmulatorCore, @unchecked Sendable {
     
-    let _bridge: PVFreeDOGameCoreBridge = .init()
+    var _bridge: PVFreeDOGameCoreBridge = .init()
     
     @objc
     public required init() {
         super.init()
-//        let core = PVFreeDOGameCoreBridge.init { key in
-//            return self.get(variable: key)
-//        }
-        let core = PVFreeDOGameCoreBridge()
-        self.bridge = (_bridge as! any ObjCBridgedCoreBridge)
+        self.bridge = _bridge as? any ObjCBridgedCoreBridge
     }
 }
 

--- a/Sources/PVFreeDOGameCoreBridge/PVFreeDOGameCoreBridge.mm
+++ b/Sources/PVFreeDOGameCoreBridge/PVFreeDOGameCoreBridge.mm
@@ -239,7 +239,6 @@ static void writeSaveFile(const char* path)
 - (instancetype)init {
     if((self = [super init])) {
         _current = self;
-        _current = self;
         videoBufferA = (uint32_t*)malloc(videoWidth * videoHeight * 4);
         videoBufferB = (uint32_t*)malloc(videoWidth * videoHeight * 4);
 //        sampleBuffer = (uintptr_t *)malloc(sizeof(uintptr_t) * TEMP_BUFFER_SIZE);
@@ -257,6 +256,7 @@ static void writeSaveFile(const char* path)
         free(self->videoBufferB);
         self->videoBufferB = nil;
     }
+    _current = nil;
 }
 
 #pragma mark Execution


### PR DESCRIPTION
### **User description**
This PR fixes the crash on load in Provenance 2.3.0.

We were creating duplicate CoreBridge instances in the init method which caused the _current pointer which is static to get NULL'd out when the duplicate instance went out of scope.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a crash on load in Provenance 2.3.0 by addressing duplicated CoreBridge instances.
- Removed redundant assignment of `_current` in the `init` method of `PVFreeDOGameCoreBridge`.
- Ensured `_current` is set to `nil` in the `dealloc` method to prevent potential issues.
- Changed `_bridge` from a constant to a variable in `FreeDOGameCore.swift` and updated initialization logic.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PVFreeDOGameCoreBridge.mm</strong><dd><code>Fix duplicate instance and cleanup in CoreBridge</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/PVFreeDOGameCoreBridge/PVFreeDOGameCoreBridge.mm

<li>Removed duplicate assignment of <code>_current</code> in the <code>init</code> method.<br> <li> Set <code>_current</code> to <code>nil</code> in the <code>dealloc</code> method to prevent dangling <br>pointers.<br>


</details>


  </td>
  <td><a href="https://github.com/Provenance-Emu/4DO-Core/pull/3/files#diff-cdc98a8e57dc8dbfd6a9e6cb3e1cd643babf688af636c1cf7da8db19a1334b4f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>FreeDOGameCore.swift</strong><dd><code>Update bridge initialization and variable declaration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Sources/PVFreeDOGameCore/FreeDOGameCore.swift

<li>Changed <code>_bridge</code> from a constant to a variable.<br> <li> Updated the initialization of <code>bridge</code> to use optional casting.<br>


</details>


  </td>
  <td><a href="https://github.com/Provenance-Emu/4DO-Core/pull/3/files#diff-c922427529aac536f344bf1d94a822c8286e45106b46aee9baf4a7d831c1b036">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information